### PR TITLE
Change OPs order

### DIFF
--- a/x/cdt/types/ops.go
+++ b/x/cdt/types/ops.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/gogo/protobuf/proto"
+	"sort"
 )
 
 type OP interface {
@@ -33,10 +34,16 @@ func (m *opManager) Add(op OP, composer OPComposer) {
 	m.opsm[k] = composer.Compose(m.opsm[k], op)
 }
 
+// OPs returns a slice of OP in increasing order
 func (m opManager) OPs() []OP {
 	var ret []OP
-	for _, ops := range m.opsm {
-		ret = append(ret, ops...)
+	keys := make([]string, 0, len(m.opsm))
+	for k := range m.opsm {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		ret = append(ret, m.opsm[k]...)
 	}
 	return ret
 }

--- a/x/cdt/types/ops_test.go
+++ b/x/cdt/types/ops_test.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestOPManager(t *testing.T) {
+	require := require.New(t)
+	expected := []OP{
+		NewInt64OP([]byte("a"), 1),
+		NewInt64OP([]byte("b"), 2),
+		NewInt64OP([]byte("c"), 3),
+		NewInt64OP([]byte("d"), 4),
+		NewInt64OP([]byte("e"), 5),
+	}
+
+	opManager := NewOPManager()
+	composer := SimpleOPComposer{}
+	opManager.Add(expected[0], composer)
+	opManager.Add(expected[4], composer)
+	opManager.Add(expected[2], composer)
+	opManager.Add(expected[3], composer)
+	opManager.Add(expected[1], composer)
+	ops := opManager.OPs()
+	require.Len(ops, 5)
+	require.Equal(expected, ops)
+}


### PR DESCRIPTION
OPManager#OPs should return ordered slice for blockchain/DLTs which has deterministic specification.